### PR TITLE
[fix] issue 7-undefined reference to clock_gettime

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -185,7 +185,7 @@ if(MINGW)
 elseif(MSVC)
     target_link_libraries( gts ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} Log4Qt strmiids.lib )
 elseif(UNIX)
-    target_link_libraries( gts ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} ${UNICAP_LIBRARIES} Log4Qt )
+    target_link_libraries( gts ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} ${UNICAP_LIBRARIES} Log4Qt rt )
 endif()
 
 # ----------------------------------------------------------------------------
@@ -229,7 +229,7 @@ if(GTS_TESTS)
         link_directories( ${gtest_BINARY_DIR} )
         target_link_libraries( gts_test ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} Log4Qt gtest strmiids.lib )
     elseif(UNIX)
-        target_link_libraries( gts_test ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} ${UNICAP_LIBRARIES} Log4Qt gtest )
+        target_link_libraries( gts_test ${OpenCV2_LIBRARIES} ${QT_LIBRARIES} ${UNICAP_LIBRARIES} Log4Qt gtest rt )
     endif()
 endif()
 


### PR DESCRIPTION
platform:
rela@yijie-ThinkPad-L412:~/work/dysonltd-gts$ uname -a
Linux yijie-ThinkPad-L412 3.2.0-55-generic #85-Ubuntu SMP Wed Oct 2 12:29:27 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

compiler:
rela@yijie-ThinkPad-L412:~/work/dysonltd-gts$ gcc --version
gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
Copyright (C) 2011 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
